### PR TITLE
Change test-job to use shared library

### DIFF
--- a/test-job/script.groovy
+++ b/test-job/script.groovy
@@ -1,16 +1,4 @@
-// pipeline {
-//     agent {
-//         label "slave1"
-//     }
-//     stages {
-//         stage("Test that it is working") {
-//             steps {
-//                 sh "echo 'The pipeline works!'"
-//             }
-//         }
-//     }
-// }
-library 'jenkins-shared-library@pipelines'
+library 'jenkins-shared-library@master'
 
 testPipeline {
     agent = 'slave1'


### PR DESCRIPTION
This change removes the previous test-job configuration so that now it uses the test-job configured in the [shared
library](https://github.com/carlosrn98/jenkins-shared-library/blob/master/vars/testPipeline.groovy) so that a more maintainable and reusable approach can be used whenever Jenkins is used.